### PR TITLE
Fix encode/decode of unsigned and negative numbers, see also #20

### DIFF
--- a/src/constants.jl
+++ b/src/constants.jl
@@ -38,6 +38,11 @@ const UINT16_MAX_PLUS_ONE = 0x10000
 const UINT32_MAX_PLUS_ONE = 0x100000000
 const UINT64_MAX_PLUS_ONE = 0x10000000000000000
 
+const INT8_MAX_POSITIVE = 0x7f
+const INT16_MAX_POSITIVE = 0x7fff
+const INT32_MAX_POSITIVE = 0x7fffffff
+const INT64_MAX_POSITIVE = 0x7fffffffffffffff
+
 const SIZE_OF_FLOAT64 = sizeof(Float64)
 const SIZE_OF_FLOAT32 = sizeof(Float32)
 const SIZE_OF_FLOAT16 = sizeof(Float16)

--- a/src/encode.jl
+++ b/src/encode.jl
@@ -79,7 +79,11 @@ function encode(io::IO, num::Unsigned)
 end
 
 function encode(io::IO, num::T) where T <: Signed
-    encode_unsigned_with_type(io, TYPE_1, unsigned(-num - one(T)))
+    if num >= 0
+        encode_smallest_int(io, TYPE_0, unsigned(num))
+    else
+        encode_smallest_int(io, TYPE_1, unsigned(-num - one(T)))
+    end
 end
 
 function encode(io::IO, byte_string::Vector{UInt8})


### PR DESCRIPTION
Actually both positive and negative values of signed integers  are encoded/decoded as major type 1, causing interoperability problems with cbor libraries implemented in other languages.

This patch is for compliance with RFC8949: positive integers as major type 0 and negative integer as major type 1.